### PR TITLE
Changed the fishing rectangle to border only

### DIFF
--- a/gui/gui_functions.py
+++ b/gui/gui_functions.py
@@ -11,7 +11,7 @@ def popup_rectangle_window(button, x, y, width, height):
     window.attributes('-fullscreen', True)
     window.wm_attributes('-transparentcolor', window['bg'])
     canvas = Canvas(window, width=10000, height=10000)
-    canvas.create_rectangle(x.get(), y.get(), x.get()+width.get(), y.get()+height.get(), fill="green")
+    canvas.create_rectangle(x.get(), y.get(), x.get()+width.get(), y.get()+height.get(), outline="green")
     canvas.pack()
     button.configure(command = partial(destroy_rectangle_window, window, button, x, y, width, height))
 


### PR DESCRIPTION
Changed the fishing rectangle to border only to see and compare the area where my bait is landing and adjust as needed.
![border](https://user-images.githubusercontent.com/9656781/136515303-720f34ee-ba17-4c4e-85ec-3e06301ec94c.jpg)

