### PR TITLE
Optimized searching for specified colors in image_recognition.py with cv::inRange()

### DIFF
--- a/functionality/image_recognition.py
+++ b/functionality/image_recognition.py
@@ -1,7 +1,6 @@
 from utils.config import dict
 from numpy import array
 import cv2 as cv
-import numpy as np
 from PIL import ImageGrab
 from utils.global_variables import WAITING_FOR_FISH, FISH_NOTICED
 

--- a/functionality/image_recognition.py
+++ b/functionality/image_recognition.py
@@ -1,6 +1,7 @@
 from utils.config import dict
 from numpy import array
 import cv2 as cv
+import numpy as np
 from PIL import ImageGrab
 from utils.global_variables import WAITING_FOR_FISH, FISH_NOTICED
 
@@ -13,28 +14,29 @@ COLOR_WAGES = 7
 
 def image_recognition_result(x, y, width, height):
     region=(x, y, x + width, y + height)
-    img = ImageGrab.grab(bbox = region)
-    img_cv = cv.cvtColor(array(img), cv.COLOR_RGB2BGR)
+    img = array(ImageGrab.grab(bbox = region))
+    img_cv = cv.cvtColor(img, cv.COLOR_RGB2BGR)
     res = cv.matchTemplate(img_cv, NOTICE, eval('cv.TM_CCOEFF_NORMED'))
     if((res >= 0.7).any()):
         return '1'
     res = cv.matchTemplate(img_cv, NOTHING, eval('cv.TM_CCOEFF_NORMED'))
     if((res >= 0.7).any()):
         return '0'
-
-    for i in range(width):
-        for j in range(height):
-            color = img.getpixel((i, j))
-            if pixel_match(color, REEL_COLOR):
-                return '2'
-            if pixel_match(color, WAIT_COLOR_BROWN):
-                return '3'
-            if pixel_match(color, WAIT_COLOR_RED):
-                return '4'
+    
+    if pixel_match(img, REEL_COLOR):     
+        return '2'
+    if pixel_match(img, WAIT_COLOR_BROWN):        
+        return '3'
+    if pixel_match(img, WAIT_COLOR_RED):                    
+        return '4'           
     return '5'
 
-def pixel_match(color, matcher):
-    for i in range (0,3):
-        if not((matcher[i] - COLOR_WAGES) <= color[i] <= (matcher[i] + COLOR_WAGES)):
-            return False
-    return True
+def pixel_match(img, matcher):
+    lower, upper = ([matcher[0] - COLOR_WAGES, matcher[1] - COLOR_WAGES,  matcher[2] - COLOR_WAGES], [matcher[0] + COLOR_WAGES, matcher[1] + COLOR_WAGES,  matcher[2] + COLOR_WAGES])
+    color_lower = array( lower)
+    color_upper = array( upper)
+
+    mask = cv.inRange(img, color_lower, color_upper)
+    if mask.any():
+        return True
+    return False


### PR DESCRIPTION
Iterating through a Python array with two nested for-loops is not as fast as openCV/Numpy can do it vectorized.
Therefore, I replaced the two for-loops by the OpenCV function `cv::inRange()` and the python array given by PIL with a numpy one.

I tried my best measuring the improvements with measuring the execution time of `call_appropriate_fishing_action()`:

Before:  ~0,3534 seconds
After:    ~0,09526 seconds 
== 3,71 times faster (median average bit smaller: 3,62)

Just the color finding part without template matching is ~175 - 200 times faster.

Another Upside: we now have all the color matching pixels and could do some math on them to get the area, e.g. for optimized reeling (all white pixels in mask).

