### PR TITLE
Variable Screen resolutions

### DIFF
--- a/functionality/image_recognition.py
+++ b/functionality/image_recognition.py
@@ -1,7 +1,6 @@
 from utils.config import dict
 from numpy import array
 import cv2 as cv
-import numpy as np
 from PIL import ImageGrab
 from utils.global_variables import WAITING_FOR_FISH, FISH_NOTICED
 

--- a/functionality/image_recognition.py
+++ b/functionality/image_recognition.py
@@ -1,6 +1,7 @@
 from utils.config import dict
 from numpy import array
 import cv2 as cv
+import numpy as np
 from PIL import ImageGrab
 from utils.global_variables import WAITING_FOR_FISH, FISH_NOTICED
 
@@ -13,28 +14,29 @@ COLOR_WAGES = 7
 
 def image_recognition_result(x, y, width, height):
     region=(x, y, x + width, y + height)
-    img = ImageGrab.grab(bbox = region)
-    img_cv = cv.cvtColor(array(img), cv.COLOR_RGB2BGR)
+    img = array(ImageGrab.grab(bbox = region))
+    img_cv = cv.cvtColor(img, cv.COLOR_RGB2BGR)
     res = cv.matchTemplate(img_cv, NOTICE, eval('cv.TM_CCOEFF_NORMED'))
     if((res >= 0.7).any()):
         return '1'
     res = cv.matchTemplate(img_cv, NOTHING, eval('cv.TM_CCOEFF_NORMED'))
     if((res >= 0.7).any()):
         return '0'
-
-    for i in range(width):
-        for j in range(height):
-            color = img.getpixel((i, j))
-            if pixel_match(color, REEL_COLOR):
-                return '2'
-            if pixel_match(color, WAIT_COLOR_BROWN):
-                return '3'
-            if pixel_match(color, WAIT_COLOR_RED):
-                return '4'
+    
+    if pixel_match(img, REEL_COLOR):     
+        return '2'
+    if pixel_match(img, WAIT_COLOR_BROWN):        
+        return '3'
+    if pixel_match(img, WAIT_COLOR_RED):                    
+        return '4'           
     return '5'
 
-def pixel_match(color, matcher):
-    for i in range (0,3):
-        if not((matcher[i] - COLOR_WAGES) <= color[i] <= (matcher[i] + COLOR_WAGES)):
-            return False
-    return True
+def pixel_match(img, matcher):
+    lower, upper = ([matcher[0] - COLOR_WAGES, matcher[1] - COLOR_WAGES,  matcher[2] - COLOR_WAGES], [matcher[0] + COLOR_WAGES, matcher[1] + COLOR_WAGES,  matcher[2] + COLOR_WAGES])
+    color_lower = array( lower)
+    color_upper = array( upper)
+
+    mask = cv.inRange(img, color_lower, color_upper)
+    if mask.any():
+        return True
+    return False

--- a/functionality/image_recognition.py
+++ b/functionality/image_recognition.py
@@ -3,13 +3,43 @@ from numpy import array
 import cv2 as cv
 from PIL import ImageGrab
 from utils.global_variables import WAITING_FOR_FISH, FISH_NOTICED
+from os import path
+import configparser
+
+#Baseline Resolution at which the templates were recorded
+base_width = 1920
+base_height = 1080
+#Get Game Resolution from user_preload_settings.cfg
+nw_config_path = path.expandvars(r'%APPDATA%\AGS\New World\user_preload_settings.cfg')
+if path.isfile(nw_config_path):
+    config = configparser.ConfigParser(allow_no_value=True)
+    with open(nw_config_path, 'r') as f:
+        config_string = '[dummy_section]\n' + f.read()
+    config.read_string(config_string)
+    scaleX = int(config['dummy_section']["r_Width"]) / base_width
+    scaleY = int(config['dummy_section']["r_Height"]) / base_height
+    print(scaleX)
+else:
+  scaleX = 1
+  scaleY = 1
 
 NOTHING = cv.imread(WAITING_FOR_FISH)
+width = int(NOTHING.shape[1] * scaleX)
+height = int(NOTHING.shape[1] * scaleY)
+dim = (width, height)  
+NOTHING = cv.resize(NOTHING, dim, cv.INTER_LINEAR)
 NOTICE = cv.imread(FISH_NOTICED)
+width = int(NOTICE.shape[1] * scaleX)
+height = int(NOTICE.shape[1] * scaleY)
+dim = (width, height)  
+NOTICE = cv.resize(NOTICE, dim, cv.INTER_LINEAR)
 REEL_COLOR = dict['colors']['green']
 WAIT_COLOR_BROWN = dict['colors']['brown']
 WAIT_COLOR_RED = dict['colors']['red']
 COLOR_WAGES = 7
+
+
+
 
 def image_recognition_result(x, y, width, height):
     region=(x, y, x + width, y + height)

--- a/functionality/image_recognition.py
+++ b/functionality/image_recognition.py
@@ -6,6 +6,7 @@ from utils.global_variables import WAITING_FOR_FISH, FISH_NOTICED
 from os import path
 import configparser
 
+
 #Baseline Resolution at which the templates were recorded
 base_width = 1920
 base_height = 1080
@@ -18,28 +19,31 @@ if path.isfile(nw_config_path):
     config.read_string(config_string)
     scaleX = int(config['dummy_section']["r_Width"]) / base_width
     scaleY = int(config['dummy_section']["r_Height"]) / base_height
-    print(scaleX)
 else:
-  scaleX = 1
-  scaleY = 1
+    scaleX = 1
+    scaleY = 1
+
+#Determine which scale to use
+aspect_factor = int(config['dummy_section']["r_Width"]) / int(config['dummy_section']["r_Height"])
+if (aspect_factor == 16/9 or aspect_factor == 16/10):
+    scale = scaleX
+elif(aspect_factor == 21/9 or aspect_factor == 32/9):
+    scale = scaleY
 
 NOTHING = cv.imread(WAITING_FOR_FISH)
-width = int(NOTHING.shape[1] * scaleX)
-height = int(NOTHING.shape[1] * scaleY)
+width = int(NOTHING.shape[1] * scale)
+height = int(NOTHING.shape[1] * scale)
 dim = (width, height)  
 NOTHING = cv.resize(NOTHING, dim, cv.INTER_LINEAR)
 NOTICE = cv.imread(FISH_NOTICED)
-width = int(NOTICE.shape[1] * scaleX)
-height = int(NOTICE.shape[1] * scaleY)
+width = int(NOTICE.shape[1] * scale)
+height = int(NOTICE.shape[1] * scale)
 dim = (width, height)  
 NOTICE = cv.resize(NOTICE, dim, cv.INTER_LINEAR)
 REEL_COLOR = dict['colors']['green']
 WAIT_COLOR_BROWN = dict['colors']['brown']
 WAIT_COLOR_RED = dict['colors']['red']
 COLOR_WAGES = 7
-
-
-
 
 def image_recognition_result(x, y, width, height):
     region=(x, y, x + width, y + height)


### PR DESCRIPTION
#28
I tried working on the screen resolution "problem".
In my first attempt I tried a multiscale template matching approach, which performed quite bad.
Just for the basic resolutions UHD, QHD, FHD and HD we do have to template match 8 times.

So I took a look at the game config files and found the desired rendering resolution in `%APPDATA%\AGS\New World\user_preload_settings.cfg`.
With this information and the knowledge at which resolution the templates were recorded, we can calculate a scale and apply this to our templates. As this should happen just at the initial loading, it should perform as good as with static template size.

I tested it on 1440p, it should work on all 16:9 game resolution. On 16:10 it would change the template aspect ratio. I'm not sure if the template matching will then still work. Maybe it would be better to just determine the scale of the width and just use this one to resize the template.

As New World dont follow the normal .cfg layout with sections, i had to insert a Dummy Section in to the configstring for configparser to work.
This PR is based on my previous one #106
