### PR TITLE
Different DPI Scale Support

### DIFF
--- a/gui/gui_functions.py
+++ b/gui/gui_functions.py
@@ -3,15 +3,29 @@ from functools import partial
 from utils.config import dict, save_data
 from functionality.fishing_loop import fishing_loop
 import utils.global_variables as gv
+from winreg import *
 
 
 def popup_rectangle_window(button, x, y, width, height):
+    #Get Windows DPI Scale
+    Registry = ConnectRegistry(None, HKEY_CURRENT_USER)
+    RawKey = OpenKey(Registry, "Control Panel\Desktop\WindowMetrics")
+    key_dict = {}
+    i = 0
+    while True:
+        try:
+            subvalue = EnumValue(RawKey, i)
+        except WindowsError as e:
+            break
+        key_dict[subvalue[0]] = subvalue[1:]
+        i+=1
     window = Toplevel()
     window.resizable(False, False)
     window.attributes('-fullscreen', True)
     window.wm_attributes('-transparentcolor', window['bg'])
     canvas = Canvas(window, width=10000, height=10000)
-    canvas.create_rectangle(x.get(), y.get(), x.get()+width.get(), y.get()+height.get(), outline="green", width=5)
+    dpiScale = (key_dict["AppliedDPI"][0] / 96)
+    canvas.create_rectangle(x.get()/ dpiScale, y.get()/ dpiScale, x.get()+width.get()/ dpiScale, y.get()+height.get()/ dpiScale, outline="green", width=5)
     canvas.pack()
     button.configure(command = partial(destroy_rectangle_window, window, button, x, y, width, height))
 

--- a/utils/global_variables.py
+++ b/utils/global_variables.py
@@ -3,6 +3,7 @@ from os import path
 import sys
 from time import time
 from tkinter import Tk
+import ctypes
 
 def rootPath():
     try:
@@ -15,7 +16,8 @@ CONFIG_PATH = path.join(ROOT_DIR, 'resources\config.yml')
 WAITING_FOR_FISH = path.join(ROOT_DIR, 'resources\\waiting_for_fish.jpg')
 FISH_NOTICED = path.join(ROOT_DIR, 'resources\\fish_noticed.jpg')
 ICON_PATH = path.join(ROOT_DIR, 'resources\\icon.ico')
-
+ 
+ctypes.windll.shcore.SetProcessDpiAwareness(1)
 continue_fishing = False
 last_repair_time = int(time())
 last_results = LastResults()


### PR DESCRIPTION
I'm not quite sure if this is the best way to deal with this problem, mainly because I never worked with Tkinter before. But with this PR the bot will work on different windows scales.

First it grabs the DPI Setting from the Windows Registry and divides it by 96 (the default) to get a scale.
This scale is then applied to the canvas.create_rectangle values to make it match the rectangle PIL.ImageGrab is actually grabbing.

Furthermore, it disables the automatic scaling from windows with the `ctypes.windll.shcore.SetProcessDpiAwareness(1)` flag.
At least until the dpi changes again while running.