### PR TITLE
Reduced waiting time after cast

### DIFF
--- a/functionality/fishing_actions.py
+++ b/functionality/fishing_actions.py
@@ -34,8 +34,8 @@ def cast():
     press_mouse_key()
     sleep(cast_timeout)
     release_mouse_key()
-    debug("Pause for: 5 s")
-    sleep(5)
+    debug("Pause for: 4 s")
+    sleep(4)
     debug("press b")
     press_key('b')
 


### PR DESCRIPTION
5 seconds leads to not being able to catch fish on a hotspot with bait. It seems to work with 4 seconds and it seems to not break anything else.